### PR TITLE
DepthNormals & Override GraphicsFormat

### DIFF
--- a/Blit.cs
+++ b/Blit.cs
@@ -12,180 +12,200 @@ using UnityEngine.Rendering.Universal;
  * - Specific access to selecting a source and destination (via current camera's color / texture id / render texture object
  * - Automatic switching to using _AfterPostProcessTexture for After Rendering event, in order to correctly handle the blit after post processing is applied
  * - Setting a _InverseView matrix (cameraToWorldMatrix), for shaders that might need it to handle calculations from screen space to world.
- *     e.g. reconstruct world pos from depth : https://twitter.com/Cyanilux/status/1269353975058501636 
+ * 		e.g. Reconstruct world pos from depth : https://www.cyanilux.com/tutorials/depth/#blit-perspective 
+ * - (URP v10) Enabling generation of DepthNormals (_CameraNormalsTexture)
+ * 		This will only include shaders who have a DepthNormals pass (mostly Lit Shaders / Graphs)
+ 		(workaround for Unlit Shaders / Graphs: https://gist.github.com/Cyanilux/be5a796cf6ddb20f20a586b94be93f2b)
  * ------------------------------------------------------------------------------------------------------------------------
  * @Cyanilux
 */
+[CreateAssetMenu(menuName = "Feature/Blit")]
 public class Blit : ScriptableRendererFeature {
 
-    public class BlitPass : ScriptableRenderPass {
+	public class BlitPass : ScriptableRenderPass {
 
-        public Material blitMaterial = null;
-        public FilterMode filterMode { get; set; }
-        
-        private BlitSettings settings;
+		public Material blitMaterial = null;
+		public FilterMode filterMode { get; set; }
 
-        private RenderTargetIdentifier source { get; set; }
-        private RenderTargetIdentifier destination { get; set; }
+		private BlitSettings settings;
 
-        RenderTargetHandle m_TemporaryColorTexture;
-        RenderTargetHandle m_DestinationTexture;
-        string m_ProfilerTag;
+		private RenderTargetIdentifier source { get; set; }
+		private RenderTargetIdentifier destination { get; set; }
 
-        public BlitPass(RenderPassEvent renderPassEvent, BlitSettings settings, string tag) {
-            this.renderPassEvent = renderPassEvent;
-            this.settings = settings;
-            blitMaterial = settings.blitMaterial;
-            m_ProfilerTag = tag;
-            m_TemporaryColorTexture.Init("_TemporaryColorTexture");
-            if (settings.dstType == Target.TextureID) {
-                m_DestinationTexture.Init(settings.dstTextureId);
-            }
-        }
+		RenderTargetHandle m_TemporaryColorTexture;
+		RenderTargetHandle m_DestinationTexture;
+		string m_ProfilerTag;
 
-        public void Setup(RenderTargetIdentifier source, RenderTargetIdentifier destination) {
-            this.source = source;
-            this.destination = destination;
-        }
+		public BlitPass(RenderPassEvent renderPassEvent, BlitSettings settings, string tag) {
+			this.renderPassEvent = renderPassEvent;
+			this.settings = settings;
+			blitMaterial = settings.blitMaterial;
+			m_ProfilerTag = tag;
+			m_TemporaryColorTexture.Init("_TemporaryColorTexture");
+			if (settings.dstType == Target.TextureID) {
+				m_DestinationTexture.Init(settings.dstTextureId);
+			}
+		}
 
-        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData) {
-            CommandBuffer cmd = CommandBufferPool.Get(m_ProfilerTag);
+		public void Setup(RenderTargetIdentifier source, RenderTargetIdentifier destination) {
+			this.source = source;
+			this.destination = destination;
 
-            RenderTextureDescriptor opaqueDesc = renderingData.cameraData.cameraTargetDescriptor;
-            opaqueDesc.depthBufferBits = 0;
+#if UNITY_2020_1_OR_NEWER
+			if (settings.requireDepthNormals)
+				ConfigureInput(ScriptableRenderPassInput.Normal);
+#endif
+		}
 
-            if (settings.setInverseViewMatrix) {
-                Shader.SetGlobalMatrix("_InverseView", renderingData.cameraData.camera.cameraToWorldMatrix);
-            }
+		public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData) {
+			CommandBuffer cmd = CommandBufferPool.Get(m_ProfilerTag);
 
-            if (settings.dstType == Target.TextureID) {
-                cmd.GetTemporaryRT(m_DestinationTexture.id, opaqueDesc, filterMode);
-            }
+			RenderTextureDescriptor opaqueDesc = renderingData.cameraData.cameraTargetDescriptor;
+			opaqueDesc.depthBufferBits = 0;
 
-            //Debug.Log($"src = {source},     dst = {destination} ");
-            // Can't read and write to same color target, use a TemporaryRT
-            if (source == destination || (settings.srcType == settings.dstType && settings.srcType == Target.CameraColor)) {
-                cmd.GetTemporaryRT(m_TemporaryColorTexture.id, opaqueDesc, filterMode);
-                Blit(cmd, source, m_TemporaryColorTexture.Identifier(), blitMaterial, settings.blitMaterialPassIndex);
-                Blit(cmd, m_TemporaryColorTexture.Identifier(), destination);
-            } else {
-                Blit(cmd, source, destination, blitMaterial, settings.blitMaterialPassIndex);
-            }
+			if (settings.setInverseViewMatrix) {
+				Shader.SetGlobalMatrix("_InverseView", renderingData.cameraData.camera.cameraToWorldMatrix);
+			}
 
-            context.ExecuteCommandBuffer(cmd);
-            CommandBufferPool.Release(cmd);
-        }
-        
-        public override void FrameCleanup(CommandBuffer cmd) {
-            if (settings.dstType == Target.TextureID) {
-                cmd.ReleaseTemporaryRT(m_DestinationTexture.id);
-            }
-            if (source == destination || (settings.srcType == settings.dstType && settings.srcType == Target.CameraColor)) {
-                cmd.ReleaseTemporaryRT(m_TemporaryColorTexture.id);
-            }
-        }
-    }
+			if (settings.dstType == Target.TextureID) {
+				if (settings.overrideGraphicsFormat){
+					opaqueDesc.graphicsFormat = settings.graphicsFormat;
+				}
+				cmd.GetTemporaryRT(m_DestinationTexture.id, opaqueDesc, filterMode);
+			}
 
-    [System.Serializable]
-    public class BlitSettings {
-        public RenderPassEvent Event = RenderPassEvent.AfterRenderingOpaques;
+			//Debug.Log($"src = {source},     dst = {destination} ");
+			// Can't read and write to same color target, use a TemporaryRT
+			if (source == destination || (settings.srcType == settings.dstType && settings.srcType == Target.CameraColor)) {
+				cmd.GetTemporaryRT(m_TemporaryColorTexture.id, opaqueDesc, filterMode);
+				Blit(cmd, source, m_TemporaryColorTexture.Identifier(), blitMaterial, settings.blitMaterialPassIndex);
+				Blit(cmd, m_TemporaryColorTexture.Identifier(), destination);
+			} else {
+				Blit(cmd, source, destination, blitMaterial, settings.blitMaterialPassIndex);
+			}
 
-        public Material blitMaterial = null;
-        public int blitMaterialPassIndex = 0;
-        public bool setInverseViewMatrix = false;
+			context.ExecuteCommandBuffer(cmd);
+			CommandBufferPool.Release(cmd);
+		}
 
-        public Target srcType = Target.CameraColor;
-        public string srcTextureId = "_CameraColorTexture";
-        public RenderTexture srcTextureObject;
+		public override void FrameCleanup(CommandBuffer cmd) {
+			if (settings.dstType == Target.TextureID) {
+				cmd.ReleaseTemporaryRT(m_DestinationTexture.id);
+			}
+			if (source == destination || (settings.srcType == settings.dstType && settings.srcType == Target.CameraColor)) {
+				cmd.ReleaseTemporaryRT(m_TemporaryColorTexture.id);
+			}
+		}
+	}
 
-        public Target dstType = Target.CameraColor;
-        public string dstTextureId = "_BlitPassTexture";
-        public RenderTexture dstTextureObject;
-    }
+	[System.Serializable]
+	public class BlitSettings {
+		public RenderPassEvent Event = RenderPassEvent.AfterRenderingOpaques;
 
-    public enum Target {
-        CameraColor,
-        TextureID,
-        RenderTextureObject
-    }
+		public Material blitMaterial = null;
+		public int blitMaterialPassIndex = 0;
+		public bool setInverseViewMatrix = false;
+		public bool requireDepthNormals = false;
 
-    public BlitSettings settings = new BlitSettings();
-    
-    BlitPass blitPass;
+		public Target srcType = Target.CameraColor;
+		public string srcTextureId = "_CameraColorTexture";
+		public RenderTexture srcTextureObject;
 
-    private RenderTargetIdentifier srcIdentifier, dstIdentifier;
+		public Target dstType = Target.CameraColor;
+		public string dstTextureId = "_BlitPassTexture";
+		public RenderTexture dstTextureObject;
 
-    public override void Create() {
-        var passIndex = settings.blitMaterial != null ? settings.blitMaterial.passCount - 1 : 1;
-        settings.blitMaterialPassIndex = Mathf.Clamp(settings.blitMaterialPassIndex, -1, passIndex);
-        blitPass = new BlitPass(settings.Event, settings, name);
+		public bool overrideGraphicsFormat = false;
+		public UnityEngine.Experimental.Rendering.GraphicsFormat graphicsFormat;
+	}
 
-        if (settings.Event == RenderPassEvent.AfterRenderingPostProcessing) {
-            Debug.LogWarning("Note that the \"After Rendering Post Processing\"'s Color target doesn't seem to work? (or might work, but doesn't contain the post processing) :( -- Use \"After Rendering\" instead!");
-        }
+	public enum Target {
+		CameraColor,
+		TextureID,
+		RenderTextureObject
+	}
 
-        UpdateSrcIdentifier();
-        UpdateDstIdentifier();
-    }
+	public BlitSettings settings = new BlitSettings();
 
-    private void UpdateSrcIdentifier() {
-        srcIdentifier = UpdateIdentifier(settings.srcType, settings.srcTextureId, settings.srcTextureObject);
-    }
+	public BlitPass blitPass;
 
-    private void UpdateDstIdentifier() {
-        dstIdentifier = UpdateIdentifier(settings.dstType, settings.dstTextureId, settings.dstTextureObject);
-    }
+	private RenderTargetIdentifier srcIdentifier, dstIdentifier;
 
-    private RenderTargetIdentifier UpdateIdentifier(Target type, string s, RenderTexture obj) {
-        if (type == Target.RenderTextureObject) {
-            return obj;
-        } else if (type == Target.TextureID) {
-            //RenderTargetHandle m_RTHandle = new RenderTargetHandle();
-            //m_RTHandle.Init(s);
-            //return m_RTHandle.Identifier();
-            return s;
-        }
-        return new RenderTargetIdentifier();
-    }
-    
-    public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData) {
+	public override void Create() {
+		var passIndex = settings.blitMaterial != null ? settings.blitMaterial.passCount - 1 : 1;
+		settings.blitMaterialPassIndex = Mathf.Clamp(settings.blitMaterialPassIndex, -1, passIndex);
+		blitPass = new BlitPass(settings.Event, settings, name);
 
-        if (settings.blitMaterial == null) {
-            Debug.LogWarningFormat("Missing Blit Material. {0} blit pass will not execute. Check for missing reference in the assigned renderer.", GetType().Name);
-            return;
-        }
+		if (settings.Event == RenderPassEvent.AfterRenderingPostProcessing) {
+			Debug.LogWarning("Note that the \"After Rendering Post Processing\"'s Color target doesn't seem to work? (or might work, but doesn't contain the post processing) :( -- Use \"After Rendering\" instead!");
+		}
 
-        if (settings.Event == RenderPassEvent.AfterRenderingPostProcessing) {
-        } else if (settings.Event == RenderPassEvent.AfterRendering && renderingData.postProcessingEnabled) {
-            // If event is AfterRendering, and src/dst is using CameraColor, switch to _AfterPostProcessTexture instead.
-            if (settings.srcType == Target.CameraColor) {
-                settings.srcType = Target.TextureID;
-                settings.srcTextureId = "_AfterPostProcessTexture";
-                UpdateSrcIdentifier();
-            }
-            if (settings.dstType == Target.CameraColor) {
-                settings.dstType = Target.TextureID;
-                settings.dstTextureId = "_AfterPostProcessTexture";
-                UpdateDstIdentifier();
-            }
-        } else {
-            // If src/dst is using _AfterPostProcessTexture, switch back to CameraColor
-            if (settings.srcType == Target.TextureID && settings.srcTextureId == "_AfterPostProcessTexture") {
-                settings.srcType = Target.CameraColor;
-                settings.srcTextureId = "";
-                UpdateSrcIdentifier();
-            }
-            if (settings.dstType == Target.TextureID && settings.dstTextureId == "_AfterPostProcessTexture") {
-                settings.dstType = Target.CameraColor;
-                settings.dstTextureId = "";
-                UpdateDstIdentifier();
-            }
-        }
-        
-        var src = (settings.srcType == Target.CameraColor) ? renderer.cameraColorTarget : srcIdentifier;
-        var dest = (settings.dstType == Target.CameraColor) ? renderer.cameraColorTarget : dstIdentifier;
-        
-        blitPass.Setup(src, dest);
-        renderer.EnqueuePass(blitPass);
-    }
+		if (settings.graphicsFormat == UnityEngine.Experimental.Rendering.GraphicsFormat.None) {
+			settings.graphicsFormat = SystemInfo.GetGraphicsFormat(UnityEngine.Experimental.Rendering.DefaultFormat.LDR);
+		}
+
+		UpdateSrcIdentifier();
+		UpdateDstIdentifier();
+	}
+
+	private void UpdateSrcIdentifier() {
+		srcIdentifier = UpdateIdentifier(settings.srcType, settings.srcTextureId, settings.srcTextureObject);
+	}
+
+	private void UpdateDstIdentifier() {
+		dstIdentifier = UpdateIdentifier(settings.dstType, settings.dstTextureId, settings.dstTextureObject);
+	}
+
+	private RenderTargetIdentifier UpdateIdentifier(Target type, string s, RenderTexture obj) {
+		if (type == Target.RenderTextureObject) {
+			return obj;
+		} else if (type == Target.TextureID) {
+			//RenderTargetHandle m_RTHandle = new RenderTargetHandle();
+			//m_RTHandle.Init(s);
+			//return m_RTHandle.Identifier();
+			return s;
+		}
+		return new RenderTargetIdentifier();
+	}
+
+	public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData) {
+
+		if (settings.blitMaterial == null) {
+			Debug.LogWarningFormat("Missing Blit Material. {0} blit pass will not execute. Check for missing reference in the assigned renderer.", GetType().Name);
+			return;
+		}
+
+		if (settings.Event == RenderPassEvent.AfterRenderingPostProcessing) {
+		} else if (settings.Event == RenderPassEvent.AfterRendering && renderingData.postProcessingEnabled) {
+			// If event is AfterRendering, and src/dst is using CameraColor, switch to _AfterPostProcessTexture instead.
+			if (settings.srcType == Target.CameraColor) {
+				settings.srcType = Target.TextureID;
+				settings.srcTextureId = "_AfterPostProcessTexture";
+				UpdateSrcIdentifier();
+			}
+			if (settings.dstType == Target.CameraColor) {
+				settings.dstType = Target.TextureID;
+				settings.dstTextureId = "_AfterPostProcessTexture";
+				UpdateDstIdentifier();
+			}
+		} else {
+			// If src/dst is using _AfterPostProcessTexture, switch back to CameraColor
+			if (settings.srcType == Target.TextureID && settings.srcTextureId == "_AfterPostProcessTexture") {
+				settings.srcType = Target.CameraColor;
+				settings.srcTextureId = "";
+				UpdateSrcIdentifier();
+			}
+			if (settings.dstType == Target.TextureID && settings.dstTextureId == "_AfterPostProcessTexture") {
+				settings.dstType = Target.CameraColor;
+				settings.dstTextureId = "";
+				UpdateDstIdentifier();
+			}
+		}
+
+		var src = (settings.srcType == Target.CameraColor) ? renderer.cameraColorTarget : srcIdentifier;
+		var dest = (settings.dstType == Target.CameraColor) ? renderer.cameraColorTarget : dstIdentifier;
+
+		blitPass.Setup(src, dest);
+		renderer.EnqueuePass(blitPass);
+	}
 }

--- a/Editor/BlitPropertyDrawer.cs
+++ b/Editor/BlitPropertyDrawer.cs
@@ -3,7 +3,7 @@ using UnityEditor;
 
 [CustomPropertyDrawer(typeof(Blit.BlitSettings))]
 public class BlitEditor : PropertyDrawer {
-
+    
     private bool createdStyles = false;
     private GUIStyle boldLabel;
 
@@ -17,10 +17,13 @@ public class BlitEditor : PropertyDrawer {
         //base.OnGUI(position, property, label);
         if (!createdStyles) CreateStyles();
         
+		// Blit Settings
         EditorGUI.BeginProperty(position, label, property);
         EditorGUI.LabelField(position, "Blit Settings", boldLabel);
         SerializedProperty _event = property.FindPropertyRelative("Event");
         EditorGUILayout.PropertyField(_event);
+
+		// "After Rendering Post Processing" Warning
         if (_event.intValue == (int)UnityEngine.Rendering.Universal.RenderPassEvent.AfterRenderingPostProcessing) {
             EditorGUILayout.HelpBox("The \"After Rendering Post Processing\" event does not work with Camera Color targets. " +
                 "Unsure how to actually obtain the target after post processing has been applied. " +
@@ -31,7 +34,11 @@ public class BlitEditor : PropertyDrawer {
         EditorGUILayout.PropertyField(property.FindPropertyRelative("blitMaterial"));
         EditorGUILayout.PropertyField(property.FindPropertyRelative("blitMaterialPassIndex"));
         EditorGUILayout.PropertyField(property.FindPropertyRelative("setInverseViewMatrix"));
+#if UNITY_2020_1_OR_NEWER
+		EditorGUILayout.PropertyField(property.FindPropertyRelative("requireDepthNormals"));
+#endif
         
+		// Source
         EditorGUILayout.Separator();
         EditorGUILayout.LabelField("Source", boldLabel);
         SerializedProperty srcType = property.FindPropertyRelative("srcType");
@@ -43,6 +50,7 @@ public class BlitEditor : PropertyDrawer {
             EditorGUILayout.PropertyField(property.FindPropertyRelative("srcTextureObject"));
         }
 
+		// Destination
         EditorGUILayout.Separator();
         EditorGUILayout.LabelField("Destination", boldLabel);
         SerializedProperty dstType = property.FindPropertyRelative("dstType");
@@ -50,14 +58,20 @@ public class BlitEditor : PropertyDrawer {
         enumValue = dstType.intValue;
         if (enumValue == (int)Blit.Target.TextureID) {
             EditorGUILayout.PropertyField(property.FindPropertyRelative("dstTextureId"));
+			
+			SerializedProperty overrideGraphicsFormat = property.FindPropertyRelative("overrideGraphicsFormat");
+			EditorGUILayout.BeginHorizontal();
+			EditorGUILayout.PropertyField(overrideGraphicsFormat);
+			if (overrideGraphicsFormat.boolValue){
+            	EditorGUILayout.PropertyField(property.FindPropertyRelative("graphicsFormat"), GUIContent.none);
+			}
+			EditorGUILayout.EndHorizontal();
         } else if (enumValue == (int)Blit.Target.RenderTextureObject) {
             EditorGUILayout.PropertyField(property.FindPropertyRelative("dstTextureObject"));
         }
-
+        
         EditorGUI.indentLevel = 1;
-
         EditorGUI.EndProperty();
-
         property.serializedObject.ApplyModifiedProperties();
     }
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Extended to allow options for :<br />
 • Setting a **_InverseView** matrix (cameraToWorldMatrix), for shaders that might need it to handle calculations from screen space to world. For example, reconstructing world position from depth, see : https://twitter.com/Cyanilux/status/1269353975058501636<br />
 • (URP v10) Enabling generation of DepthNormals (_CameraNormalsTexture)
 <br /><br />
-Based on the Blit (now renamed to FullscreenPass) from the [UniversalRenderingExamples](https://github.com/Unity-Technologies/UniversalRenderingExamples/tree/master/Assets/Scripts/Runtime/RenderPasses)
+Based on the Blit (now renamed to FullscreenFeature/Pass) from the [UniversalRenderingExamples](https://github.com/Unity-Technologies/UniversalRenderingExamples/tree/master/Assets/Scripts/Runtime/RenderPasses)
 <br /><br />
 @Cyanilux<br />
 :)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 ## Blit Renderer Feature
-Based on the Blit from the [UniversalRenderingExamples](https://github.com/Unity-Technologies/UniversalRenderingExamples/tree/master/Assets/Scripts/Runtime/RenderPasses)<br />
-<br />
+Tested with **2019.3 / URP v8.2** and **2020.3 / URP v10.3**.
+<br /><br />
 Extended to allow options for :<br />
 • Specific access to selecting a **source** and **destination** (via current camera's color / texture id / render texture object<br />
 • Automatic switching to using **_AfterPostProcessTexture** for **After Rendering** event, in order to correctly handle the blit after post processing is applied<br />
 • Setting a **_InverseView** matrix (cameraToWorldMatrix), for shaders that might need it to handle calculations from screen space to world. For example, reconstructing world position from depth, see : https://twitter.com/Cyanilux/status/1269353975058501636<br />
-<br />
-Only tested with **2020.1.2f1** and **URP v8.2.0**.<br />
-<br />
+• (URP v10) Enabling generation of DepthNormals (_CameraNormalsTexture)
+<br /><br />
+Based on the Blit (now renamed to FullscreenPass) from the [UniversalRenderingExamples](https://github.com/Unity-Technologies/UniversalRenderingExamples/tree/master/Assets/Scripts/Runtime/RenderPasses)
+<br /><br />
 @Cyanilux<br />
 :)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Tested with **2019.3 / URP v8.2** and **2020.3 / URP v10.3**.
 <br /><br />
 Extended to allow options for :<br />
-• Specific access to selecting a **source** and **destination** (via current camera's color / texture id / render texture object<br />
+• Specific access to selecting a **source** and **destination** (via current camera's color / texture id / render texture object)<br />
 • Automatic switching to using **_AfterPostProcessTexture** for **After Rendering** event, in order to correctly handle the blit after post processing is applied<br />
 • Setting a **_InverseView** matrix (cameraToWorldMatrix), for shaders that might need it to handle calculations from screen space to world. For example, reconstructing world position from depth, see : https://twitter.com/Cyanilux/status/1269353975058501636<br />
 • (URP v10) Enabling generation of DepthNormals (_CameraNormalsTexture)


### PR DESCRIPTION
Added "Require Depth Normals" option, to enable generation of DepthNormals (_CameraNormalsTexture), also see #3
Added option to override GraphicsFormat for Destination when using Texture ID